### PR TITLE
Fix generated model equality check implementation

### DIFF
--- a/mailmojo/models/contact.py
+++ b/mailmojo/models/contact.py
@@ -168,6 +168,9 @@ class Contact(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, Contact):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/contact_list_associations.py
+++ b/mailmojo/models/contact_list_associations.py
@@ -226,6 +226,9 @@ class ContactListAssociations(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ContactListAssociations):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/contacts.py
+++ b/mailmojo/models/contacts.py
@@ -142,6 +142,9 @@ class Contacts(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, Contacts):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/embed.py
+++ b/mailmojo/models/embed.py
@@ -174,6 +174,9 @@ class Embed(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, Embed):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/embed_options.py
+++ b/mailmojo/models/embed_options.py
@@ -226,6 +226,9 @@ class EmbedOptions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, EmbedOptions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/import_result.py
+++ b/mailmojo/models/import_result.py
@@ -142,6 +142,9 @@ class ImportResult(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ImportResult):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/list.py
+++ b/mailmojo/models/list.py
@@ -458,6 +458,9 @@ class List(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, List):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/minimal_user.py
+++ b/mailmojo/models/minimal_user.py
@@ -227,6 +227,9 @@ class MinimalUser(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, MinimalUser):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/subscriber.py
+++ b/mailmojo/models/subscriber.py
@@ -182,6 +182,9 @@ class Subscriber(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, Subscriber):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/mailmojo/models/user.py
+++ b/mailmojo/models/user.py
@@ -342,6 +342,9 @@ class User(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, User):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):


### PR DESCRIPTION
The generated models include an `__eq__` implementation. This implementation did no validation of the `other` argument and blindly tried accessing its `__dict__` property. This property does not exist for all values in Python, and as such the check would crash when checking against these values.

This adds a simple sanity check at the beginning of each `__eq__` method, verifying that the `other` argument is an instance of the model. If not it is obviously not equal to the model instance running the check.